### PR TITLE
Update SimplexThread.cpp

### DIFF
--- a/src/Threads/SimplexThread.cpp
+++ b/src/Threads/SimplexThread.cpp
@@ -77,7 +77,7 @@ bool SimplexThread::findCenter(SimplexList* simplexList)
     }
 
     float boxRowLength = sqrt(numPoints);
-    float boxIncr = boxSize / sqrt(numPoints);
+    float boxIncr = boxSize / sqrt(numPoints) + 1;
 
     float radiusOfInfluence = configData->getParam(simplexCfg,QString("influenceradius")).toFloat();
     float convergeCriterion = configData->getParam(simplexCfg,QString("convergence")).toFloat();

--- a/src/Threads/SimplexThread.cpp
+++ b/src/Threads/SimplexThread.cpp
@@ -77,7 +77,7 @@ bool SimplexThread::findCenter(SimplexList* simplexList)
     }
 
     float boxRowLength = sqrt(numPoints);
-    float boxIncr = boxSize / sqrt(numPoints) + 1;
+    float boxIncr = boxSize / (sqrt(numPoints) - 1);
 
     float radiusOfInfluence = configData->getParam(simplexCfg,QString("influenceradius")).toFloat();
     float convergeCriterion = configData->getParam(simplexCfg,QString("convergence")).toFloat();


### PR DESCRIPTION
The modified equation: **boxIncr = boxSize / (sqrt(numPoints) - 1)**

- Reason: The updated equation can distribute the points evenly in the box as an sqrt(numpoints) by sqrt(numpoints) matrix. 

- Example: Assuming the boxdiameter is set as 12, and numpoints is set as 16. In order to match up the box dimension and distribute the 16 points evenly in the box, the box increment is 4 rather than 3 (the old formula), which means that we distribute the points at 0,4,8,12 on the x axis. The y axis follows the same rule here. 

**Note: The first index of the C++ program is 0.

Thus, to have a reasonable setting of boxSize and numPoints, these three settings are recommended to use/test:

1. boxSize = 12, numPoints = 16 -> boxIncr = 4  (defalut setting in VORTRAC)
2. boxSize = 24, numPoints = 16 -> boxIncr = 8
3. boxSize = 20, numPoints = 25 -> boxIncr = 5
